### PR TITLE
fix: correct usage of IntentsBitField

### DIFF
--- a/content/intro.md
+++ b/content/intro.md
@@ -65,7 +65,7 @@ import { IntentsBitField } from 'discord.js';
     imports: [
         NecordModule.forRoot({
             token: 'DISCORD_BOT_TOKEN',
-            intents: [IntentsBitField.Guilds]
+            intents: [IntentsBitField.Flags.Guilds]
         })
     ],
     providers: []


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Correct usage of `IntentsBitField`. `Guilds` doesn't exist in `IntentsBitField`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
